### PR TITLE
Docs/commits convention

### DIFF
--- a/exercices/tp1.md
+++ b/exercices/tp1.md
@@ -43,7 +43,7 @@ Type de commit:
 * feat : ajout d’une nouvelle fonctionnalité
 * fix : correction d’un bug
 * perf : amélioration des performances
-* refactor : modification qui n’apporte ni nouvelle fonctionalité ni d’amélioration de performances
+* refactor : modification de l'architecture logicielle ou modification qui n’apporte ni nouvelle fonctionnalité ni d’amélioration de performances
 * style : changement qui n’apporte aucune alteration fonctionnelle ou sémantique (indentation, mise en forme, ajout d’espace, renommante d’une variable…)
 * docs : rédaction ou mise à jour de documentation
 * test : ajout ou modification de tests
@@ -53,7 +53,11 @@ Type de commit:
 Suivre Conventional Commits https://www.conventionalcommits.org/en/v1.0.0/
 
 ### Quoi et quand commiter ?
-Il n'y a pas de requis minimum pour un commit excepté que l'application doit compiler.
+Il n'y a pas de requis minimum pour un commit excepté que l'application doit compiler.  
+
+**Exception** : quand un membre de l'équipe bloque et qu'il a besoin d'aide; 
+même si son code ne compile pas, il peut quand même commit.
+
 Ex : Faire un commit "random" pour qu'un collègue puisse continuer.
 
 ## Pull request


### PR DESCRIPTION
# Commits Convention
## Decription:
In the review of the first report, we've been asked to further detail the documentation on the commit convention that we will use for the rest of the project.
## Success criteria
 - [X] Added commit format and full list of commit types
## Technical details
Format:
```
<scope>: <subject>
<description>
```
Types of commit:
* build
* ci
* feat
* fix
* perf
* refactor
* style
* docs
* test
* revert